### PR TITLE
Login Command Check

### DIFF
--- a/cmd/azurePeering.go
+++ b/cmd/azurePeering.go
@@ -27,7 +27,7 @@ var azurePeeringCmd = &cobra.Command{
 var azurePeeringCreateCmd = &cobra.Command{
 	Use:     "create",
 	Short:   "This command creates Azure vNet Peering between your own vNet and your Enterprise Hazelcast cluster vNet.",
-	Example: "hzcloud azure-peering create --cluster-id=1 --project-id=2 --network-name=3",
+	Example: "hzcloud azure-peering create --cluster-id=1 --tenant-id=foo --subscription-id=bar --resource-group=baz --vnet=qux",
 	Run: func(cmd *cobra.Command, args []string) {
 		client := internal.NewClient()
 		indicator := util.NewLoadingIndicator("Azure Peering starting...", 100)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/fatih/color"
 	"github.com/hazelcast/hazelcast-cloud-cli/internal"
-	hazelcastcloud "github.com/hazelcast/hazelcast-cloud-sdk-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 	"os"
@@ -26,16 +25,9 @@ var loginCmd = &cobra.Command{
 		apiKeyString := strings.TrimSpace(string(apiKey))
 		apiSecretString := strings.TrimSpace(string(apiSecret))
 
-		apiUrl := os.Getenv("HZ_CLOUD_API_URL")
-		var clientErr error
-		if len(apiUrl) != 0 {
-			_, _, clientErr = hazelcastcloud.NewFromCredentials(apiKeyString, apiSecretString,
-				hazelcastcloud.OptionEndpoint(apiUrl))
-		} else {
-			_, _, clientErr = hazelcastcloud.NewFromCredentials(apiKeyString, apiSecretString)
-		}
-		internal.Validate(nil, nil, clientErr)
-		if clientErr == nil {
+		loginResult, response, loginErr := internal.Login(apiKeyString, apiSecretString)
+		internal.Validate(loginResult, response, loginErr)
+		if loginErr == nil {
 			configService := internal.NewConfigService()
 			configService.Set(internal.ApiKey, apiKeyString)
 			configService.Set(internal.ApiSecret, apiSecretString)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -16,10 +16,10 @@ var loginCmd = &cobra.Command{
 	Aliases: []string{"login"},
 	Short:   "This command logins you to Hazelcast Cloud with api-key and api-secret.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Print("- API Key: ")
+		fmt.Print("API Key: ")
 		apiKey, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
 		fmt.Printf("\r\033[K")
-		fmt.Print("- API Secret: ")
+		fmt.Print("API Secret: ")
 		apiSecret, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
 		fmt.Printf("\r\033[K")
 		apiKeyString := strings.TrimSpace(string(apiKey))
@@ -31,7 +31,7 @@ var loginCmd = &cobra.Command{
 			configService := internal.NewConfigService()
 			configService.Set(internal.ApiKey, apiKeyString)
 			configService.Set(internal.ApiSecret, apiSecretString)
-			color.Green("Login successful.")
+			color.Green("You have successfully logged into Hazelcast Cloud.")
 		}
 		return nil
 	},

--- a/internal/hazelcastCloud.go
+++ b/internal/hazelcastCloud.go
@@ -8,13 +8,9 @@ import (
 	"strings"
 )
 
-var hazelcastCloudClient *hazelcastcloud.Client
-
 func NewClient() *hazelcastcloud.Client {
 	var apiKey = os.Getenv("HZ_CLOUD_API_KEY")
 	var apiSecret = os.Getenv("HZ_CLOUD_API_SECRET")
-	var apiUrl = os.Getenv("HZ_CLOUD_API_URL")
-	var client interface{}
 
 	if len(strings.TrimSpace(apiKey)) == 0 || len(strings.TrimSpace(apiSecret)) == 0 {
 		configService := NewConfigService()
@@ -29,14 +25,15 @@ func NewClient() *hazelcastcloud.Client {
 		os.Exit(1)
 	}
 
-	if len(strings.TrimSpace(apiUrl)) != 0 {
-		client = Validate(hazelcastcloud.NewFromCredentials(apiKey, apiSecret, hazelcastcloud.OptionEndpoint(apiUrl)))
-	} else {
-		client = Validate(hazelcastcloud.NewFromCredentials(apiKey, apiSecret))
-	}
+	return Validate(Login(apiKey, apiSecret)).(*hazelcastcloud.Client)
+}
 
-	hazelcastCloudClient = client.(*hazelcastcloud.Client)
-	return hazelcastCloudClient
+func Login(apiKey string, apiSecret string) (*hazelcastcloud.Client, *hazelcastcloud.Response, error) {
+	var apiUrl = os.Getenv("HZ_CLOUD_API_URL")
+	if len(strings.TrimSpace(apiUrl)) != 0 {
+		return hazelcastcloud.NewFromCredentials(apiKey, apiSecret, hazelcastcloud.OptionEndpoint(apiUrl))
+	}
+	return hazelcastcloud.NewFromCredentials(apiKey, apiSecret)
 }
 
 func Validate(a interface{}, b *hazelcastcloud.Response, c error) interface{} {

--- a/internal/hazelcastCloud.go
+++ b/internal/hazelcastCloud.go
@@ -42,7 +42,7 @@ func NewClient() *hazelcastcloud.Client {
 func Validate(a interface{}, b *hazelcastcloud.Response, c error) interface{} {
 	if c != nil {
 		if reflect.TypeOf(c) == reflect.TypeOf(&hazelcastcloud.ErrorResponse{}) {
-			color.Red("Message:%s CorrelationId:%s", c.(*hazelcastcloud.ErrorResponse).Message,
+			color.Red("Message:%s\nCorrelationId:%s", c.(*hazelcastcloud.ErrorResponse).Message,
 				c.(*hazelcastcloud.ErrorResponse).CorrelationId)
 		} else {
 			color.Red(c.Error())


### PR DESCRIPTION
This pull request adds login to check whether the provided ApiKey and ApiSecret is correct. Also, CorrelationId now can be seen in the next new line on error messages for better readability and azure peering create command example fixed. 
closes #9