### PR TITLE
Resume Command Message

### DIFF
--- a/cmd/starterCluster.go
+++ b/cmd/starterCluster.go
@@ -120,7 +120,7 @@ var starterClusterResumeCmd = &cobra.Command{
 		clusterResponse := internal.Validate(client.StarterCluster.Resume(context.Background(), &models.ClusterResumeInput{
 			ClusterId: starterClusterId,
 		})).(*models.ClusterId)
-		color.Blue("Cluster %d stopped.", clusterResponse.ClusterId)
+		color.Blue("Cluster %d resumed.", clusterResponse.ClusterId)
 	},
 }
 


### PR DESCRIPTION
This pull request fixes the wrong message that prints when resuming a cluster.
closes #17 