### PR TITLE
Installer Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
  <img alt="Screenshot" src="https://user-images.githubusercontent.com/1237982/97022384-b901a780-155c-11eb-87b4-5f4e945a0f1c.png" />
 
 ## Installing `hzcloud`
-This guide shows how to install the Hazelcast Cloud CLI. Hazelcast Cloud CLI can be installed either from source, or from pre-built binary releases.
+These instructions show how to you can install the Hazelcast Cloud CLI from different sources. Hazelcast Cloud CLI can be installed either from direct binary releases, or from source.
 
 ### From Homebrew
 ```sh
@@ -117,4 +117,4 @@ Contributions, issues and feature requests are welcome!<br />Feel free to check 
 
 Copyright © 2020 [Hazelcast](https://github.com/hazelcast).<br />
 This project is [Apache License 2.0](https://github.com/hazelcast/hazelcast-cloud-cli) licensed.<br /><br />
-<img alt="logo" width="300" src="https://cloud.hazelcast.com/static/images/hz-cloud-logo.svg" />
+<img alt="logo" width="300" src="https://cloud.hazelcast.com/images/hz-cloud-logo.svg" />

--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ Contributions, issues and feature requests are welcome!<br />Feel free to check 
 
 Copyright © 2020 [Hazelcast](https://github.com/hazelcast).<br />
 This project is [Apache License 2.0](https://github.com/hazelcast/hazelcast-cloud-cli) licensed.<br /><br />
-<img alt="logo" width="300" src="https://cloud.hazelcast.com/images/hz-cloud-logo.svg" />
+<img alt="logo" width="300" src="https://hazelcast-cloud-static-content.s3-us-west-2.amazonaws.com/hz-cloud-logo.svg" />

--- a/README.md
+++ b/README.md
@@ -13,34 +13,27 @@
  <img alt="Screenshot" src="https://user-images.githubusercontent.com/1237982/97022384-b901a780-155c-11eb-87b4-5f4e945a0f1c.png" />
 
 ## Installing `hzcloud`
-### Using a Package Manager (Homebrew)
+This guide shows how to install the Hazelcast Cloud CLI. Hazelcast Cloud CLI can be installed either from source, or from pre-built binary releases.
+
+### From Homebrew
 ```sh
 brew tap hazelcast/hz
 brew install hzcloud
 ```
-### Downloading a Release from GitHub
-Visit the [Releases page](https://github.com/hazelcast/hazelcast-cloud-cli/releases) for the
-[`hzcloud` GitHub project](https://github.com/hazelcast/hazelcast-cloud-cli), and find the version for your operating system and architecture. Then place it into your directory with name `hzcloud` or `hzcloud.exe` for Windows.
 
-**Linux** 
-```sh
-wget \
-  https://github.com/hazelcast/hazelcast-cloud-cli/releases/latest/download/hzcloud-linux-amd64 \
-  -O /usr/local/bin/hzcloud && chmod +x /usr/local/bin/hzcloud
+### From the Script
+Hazelcast Cloud CLI has an installer script that will automatically grab the latest version according to your Operating System and Architecture.
 ```
-**Windows** 
-```sh
-curl -o hzcloud.exe `
-  https://github.com/hazelcast/hazelcast-cloud-cli/releases/latest/download/hzcloud-windows-amd64
+curl https://raw.githubusercontent.com/hazelcast/hazelcast-cloud-cli/master/scripts/install.sh | bash
 ```
-On Windows, in order to use `hzcloud` on everywhere you need to put `hzcloud.exe` into your PATH.
 
-**MacOS** 
-```sh
-wget \
-  https://github.com/hazelcast/hazelcast-cloud-cli/releases/latest/download/hzcloud-darwin-amd64 \
-  -O /usr/local/bin/hzcloud && chmod +x /usr/local/bin/hzcloud
-```
+### From the Binary Releases
+Every release of Hazelcast Cloud CLI provides binary releases for a variety of OSes. These binary versions can be manually downloaded and installed.
+1. Visit the [Releases page](https://github.com/hazelcast/hazelcast-cloud-cli/releases)
+2. Find the version for your operating system and architecture and download.
+3. Place it into your directory with name `hzcloud` or `hzcloud.exe` for Windows.
+ 
+ 
 ## Authentication with Hazelcast Cloud
 After a successful installation, in order to use, you need to authenticate with Hazelcast Cloud by providing access tokens, which can be created from `Developers` tab in [Hazelcast Cloud](https://cloud.hazelcast.com/settings/developer). You can check how to generate API Key and API Secret following the [Hazelcast Cloud Documentation](https://docs.cloud.hazelcast.com/docs/developer).
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@
  <img alt="Screenshot" src="https://user-images.githubusercontent.com/1237982/97022384-b901a780-155c-11eb-87b4-5f4e945a0f1c.png" />
 
 ## Installing `hzcloud`
-These instructions show how to you can install the Hazelcast Cloud CLI from different sources. Hazelcast Cloud CLI can be installed either from direct binary releases, or from source.
+These instructions show how you can install the Hazelcast Cloud CLI in different ways. 
 
-### From Homebrew
+### From the Installer Script
+Hazelcast Cloud CLI has an installer script that will automatically grab the latest binary version according to your operating system and architecture.
+You can fetch this script and then execute it on your local.
+```
+curl https://raw.githubusercontent.com/hazelcast/hazelcast-cloud-cli/master/scripts/install.sh | bash
+```
+
+### From the Homebrew 
+You can install Hazelcast Cloud CLI from Homebrew on your macOS. To do that, you need to tap our official repository and then install. 
 ```sh
 brew tap hazelcast/hz
 brew install hzcloud
-```
-
-### From the Script
-Hazelcast Cloud CLI has an installer script that will automatically grab the latest version according to your Operating System and Architecture.
-```
-curl https://raw.githubusercontent.com/hazelcast/hazelcast-cloud-cli/master/scripts/install.sh | bash
 ```
 
 ### From the Binary Releases
@@ -32,7 +34,7 @@ Every release of Hazelcast Cloud CLI provides binary releases for a variety of O
 1. Visit the [Releases page](https://github.com/hazelcast/hazelcast-cloud-cli/releases)
 2. Find the version for your operating system and architecture and download.
 3. Place it into your directory with name `hzcloud` or `hzcloud.exe` for Windows.
- 
+
  
 ## Authentication with Hazelcast Cloud
 After a successful installation, in order to use, you need to authenticate with Hazelcast Cloud by providing access tokens, which can be created from `Developers` tab in [Hazelcast Cloud](https://cloud.hazelcast.com/settings/developer). You can check how to generate API Key and API Secret following the [Hazelcast Cloud Documentation](https://docs.cloud.hazelcast.com/docs/developer).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+initArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+    armv5*) ARCH="armv5";;
+    armv6*) ARCH="armv6";;
+    armv7*) ARCH="arm";;
+    aarch64) ARCH="arm64";;
+    x86) ARCH="386";;
+    x86_64) ARCH="amd64";;
+    i686) ARCH="386";;
+    i386) ARCH="386";;
+  esac
+}
+
+initOS() {
+  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+}
+
+isSupported() {
+  local supported="darwin-amd64\ndarwin-arm64\nlinux-amd64\nlinux-arm\nlinux-arm64\nwindows-amd64\nwindows-arm"
+  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "No prebuilt binary for ${OS}-${ARCH}."
+    echo "To build from source, go to https://github.com/hazelcast/hazelcast-cloud-cli"
+    exit 1
+  fi
+
+  if ! type "curl" > /dev/null && ! type "wget" > /dev/null; then
+    echo "Either curl or wget is required"
+    exit 1
+  fi
+}
+
+download() {
+  HZCLOUD_DIST="hzcloud-$OS-$ARCH"
+  DOWNLOAD_URL="https://github.com/hazelcast/hazelcast-cloud-cli/releases/latest/download/$HZCLOUD_DIST"
+  HZCLOUD_TMP_ROOT="$(mktemp -dt hzcloud-installer-XXXXXX)"
+  HZCLOUD_TMP_FILE="$HZCLOUD_TMP_ROOT/$HZCLOUD_DIST"
+  echo "Downloading $DOWNLOAD_URL"
+  if type "curl" > /dev/null; then
+    curl -SsL "$DOWNLOAD_URL" -o "$HZCLOUD_TMP_FILE"
+  elif type "wget" > /dev/null; then
+    wget -q -O "$HZCLOUD_TMP_FILE" "$DOWNLOAD_URL"
+  fi
+}
+
+runAsRoot() {
+  local CMD="$*"
+  if [ $EUID -ne 0 ]; then
+    CMD="sudo $CMD"
+  fi
+  $CMD
+}
+
+install() {
+  INSTALL_DIR="/usr/local/bin"
+  INSTALL_NAME="hzcloud"
+  runAsRoot mv "$HZCLOUD_TMP_FILE" "$INSTALL_DIR/$INSTALL_NAME"
+  runAsRoot chmod +x "$INSTALL_DIR/$INSTALL_NAME"
+  echo "Installation finished. Run hzcloud to start!"
+}
+
+initArch
+initOS
+isSupported
+download
+install


### PR DESCRIPTION
This pull request adds unified installer support for Hazelcast Cloud CLI for a better experience. Also fixes logo at the bottom of the readme. 
You can run the following command to test it.
```
curl https://raw.githubusercontent.com/yunussandikci/hazelcast-cloud-cli/feature/downloader/scripts/install.sh | bash
```


closes #4 and #16
 
cc @jerrinot 