### PR TITLE
HZC-2082: Hazelcast Version Improvements

### DIFF
--- a/cmd/enterpriseCluster.go
+++ b/cmd/enterpriseCluster.go
@@ -26,7 +26,7 @@ var enterpriseClusterCmd = &cobra.Command{
 var enterpriseClusterCreateCmd = &cobra.Command{
 	Use:     "create",
 	Short:   "This command creates Hazelcast instance with provided configurations.",
-	Example: "hzcloud enterprise-cluster create --name=mycluster2 --cloud-provider=aws --region=eu-west-2 --hazelcast-version=4.0 --instance-type=m5.large --cidr-block=10.0.80.0/16 --native-memory=4 --wait",
+	Example: "hzcloud enterprise-cluster create --name=mycluster2 --cloud-provider=aws --region=eu-west-2 --zone-type=SINGLE --hazelcast-version=4.0 --instance-type=m5.large --cidr-block=10.80.0.0/16 --native-memory=4 --wait",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		zoneType, err := util.AugmentZoneType(enterpriseClusterCreateZoneType)
 		if err != nil {

--- a/cmd/starterCluster.go
+++ b/cmd/starterCluster.go
@@ -15,7 +15,6 @@ var starterClusterId string
 var starterClusterCreateInput models.CreateStarterClusterInput
 
 var starterClusterCreateClusterType string
-var starterClusterCreateHazelcastVersion float64
 
 var starterClusterCmd = &cobra.Command{
 	Use:     "starter-cluster",
@@ -34,13 +33,7 @@ var starterClusterCreateCmd = &cobra.Command{
 			return err
 		}
 
-		hazelcastVersion, err2 := util.AugmentStarterHazelcastVersion(starterClusterCreateHazelcastVersion)
-		if err2 != nil {
-			return err2
-		}
-
 		starterClusterCreateInput.ClusterType = clusterType
-		starterClusterCreateInput.HazelcastVersion = hazelcastVersion
 		cluster := internal.Validate(client.StarterCluster.Create(context.Background(), &starterClusterCreateInput)).(*models.Cluster)
 		color.Green("Cluster %s is creating. You can check the status using hzcloud starter-cluster list.", cluster.Id)
 		return nil
@@ -142,7 +135,7 @@ func init() {
 	_ = starterClusterCreateCmd.MarkFlagRequired("cluster-type")
 	starterClusterCreateCmd.Flags().Float64Var(&starterClusterCreateInput.TotalMemory, "total-memory", 0, "total memory of cluster as gb")
 	_ = starterClusterCreateCmd.MarkFlagRequired("total-memory")
-	starterClusterCreateCmd.Flags().Float64Var(&starterClusterCreateHazelcastVersion, "hazelcast-version", 0, "version of hazelcast")
+	starterClusterCreateCmd.Flags().StringVar(&starterClusterCreateInput.HazelcastVersion, "hazelcast-version", "", "version of hazelcast")
 	_ = starterClusterCreateCmd.MarkFlagRequired("hazelcast-version")
 
 	starterClusterCreateCmd.Flags().BoolVar(&starterClusterCreateInput.IsAutoScalingEnabled, "auto-scaling-enabled", false, "auto scaling feature")

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.3.0
-	github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211129100341-48b5c237a21b
+	github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,15 +17,15 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.3.0
-	github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.0
+	github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211129100341-48b5c237a21b
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/spf13/cobra v1.2.1
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 // indirect
 	golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/api v0.58.0
 	google.golang.org/genproto v0.0.0-20211001223012-bfb93cce50d9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,14 +232,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.1 h1:ZTS8mqqrkazc47SaqMIOBfKNsvUxunr4gN/BRZ1rB5E=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.1/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211126102558-f5bcdba686cf h1:RLXraRQHabgoR62PQ6hV3E5rmZVKmxTed5SbRlQDjZQ=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211126102558-f5bcdba686cf/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211126103525-71b7625b98b9 h1:1BIwn3uo9UWbK6+iWlxx7LNoN2svDwtLHRS6TePixx4=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211126103525-71b7625b98b9/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211129100341-48b5c237a21b h1:mDr6GocGRjdnbE+W8ncQsMi3BMW4nqv0Oh//2gNIAkk=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211129100341-48b5c237a21b/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2 h1:qeWmMA/oHjwe0cWhFLc+Zu9wlQ2s+GjZLe5n0mOeL/Q=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,14 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.0 h1:swp6lJr3fkNZHry2UqukwUIBgod9Fnh5s0vh8PuTCj4=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.0/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.1 h1:ZTS8mqqrkazc47SaqMIOBfKNsvUxunr4gN/BRZ1rB5E=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.1/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211126102558-f5bcdba686cf h1:RLXraRQHabgoR62PQ6hV3E5rmZVKmxTed5SbRlQDjZQ=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211126102558-f5bcdba686cf/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211126103525-71b7625b98b9 h1:1BIwn3uo9UWbK6+iWlxx7LNoN2svDwtLHRS6TePixx4=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211126103525-71b7625b98b9/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211129100341-48b5c237a21b h1:mDr6GocGRjdnbE+W8ncQsMi3BMW4nqv0Oh//2gNIAkk=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2-0.20211129100341-48b5c237a21b/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -11,18 +11,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/list"
 )
 
-func AugmentStarterHazelcastVersion(starterClusterCreateHazelcastVersion float64) (models.StarterHazelcastVersion, error) {
-	switch starterClusterCreateHazelcastVersion {
-	case 3.12:
-		return models.Version312, nil
-	case 4.0:
-		return models.Version40, nil
-	default:
-		return "", errors.New("you can only select 3.12 or 4.0 for Hazelcast version")
-	}
-}
-
-func AugmentStarterClusterType(starterClusterCreateClusterType string) (models.StarterClusterType, error) {
+func  AugmentStarterClusterType(starterClusterCreateClusterType string) (models.StarterClusterType, error) {
 	switch strings.ToUpper(starterClusterCreateClusterType) {
 	case "FREE":
 		return models.Free, nil
@@ -66,6 +55,7 @@ func printCluster(cluster models.Cluster, printStyle PrintStyle) {
 
 	wr.AppendItem(fmt.Sprintf("Id: %s", cluster.Id))
 	wr.AppendItem(fmt.Sprintf("Name: %s", cluster.Name))
+	wr.AppendItem(fmt.Sprintf("Release Name: %s", cluster.ReleaseName))
 	wr.AppendItem(fmt.Sprintf("Customer Id: %d", cluster.CustomerId))
 	wr.AppendItem(fmt.Sprintf("Password: %s", cluster.Password))
 	wr.AppendItem(fmt.Sprintf("Port: %d", cluster.Port))

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/list"
 )
 
-func  AugmentStarterClusterType(starterClusterCreateClusterType string) (models.StarterClusterType, error) {
+func AugmentStarterClusterType(starterClusterCreateClusterType string) (models.StarterClusterType, error) {
 	switch strings.ToUpper(starterClusterCreateClusterType) {
 	case "FREE":
 		return models.Free, nil
@@ -54,8 +54,8 @@ func printCluster(cluster models.Cluster, printStyle PrintStyle) {
 	wr.SetStyle(list.StyleConnectedBold)
 
 	wr.AppendItem(fmt.Sprintf("Id: %s", cluster.Id))
-	wr.AppendItem(fmt.Sprintf("Name: %s", cluster.Name))
-	wr.AppendItem(fmt.Sprintf("Release Name: %s", cluster.ReleaseName))
+	wr.AppendItem(fmt.Sprintf("Display Name: %s", cluster.Name))
+	wr.AppendItem(fmt.Sprintf("Cluster Name: %s", cluster.ReleaseName))
 	wr.AppendItem(fmt.Sprintf("Customer Id: %d", cluster.CustomerId))
 	wr.AppendItem(fmt.Sprintf("Password: %s", cluster.Password))
 	wr.AppendItem(fmt.Sprintf("Port: %d", cluster.Port))


### PR DESCRIPTION
Note: This PR depends on a[ task](https://github.com/hazelcast/hazelcast-cloud/pull/4799) that should be released to prod first, will stay as draft until then.
- Hazelcast new go sdk is used to be able to pass correct hazelcast versions.

Tested with current prod (3.4.0)

**Properly reports starter hz versions** 
![Screen Shot 2022-01-20 at 12 34 34](https://user-images.githubusercontent.com/1237982/150312324-9cdebc26-59df-4009-8f6a-5a6329a12f74.png)

**Properly reports enterprise hz versions**
![Screen Shot 2022-01-20 at 12 35 31](https://user-images.githubusercontent.com/1237982/150312441-08bcca00-04e9-4ee4-a80a-a101b9b0f853.png)

