### PR TITLE
HZC-2715: Serverless cluster support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
 
       - name: Install staticcheck
-        run: go get -u golang.org/x/tools/... && go get honnef.co/go/tools/cmd/staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@2020.2.1
 
       - name: Run 'go vet'
         run: go vet ./...

--- a/cmd/serverless_cluster.go
+++ b/cmd/serverless_cluster.go
@@ -143,6 +143,28 @@ func newServerlessClusterStopCmd() *cobra.Command {
 	return serverlessClusterStopCmd
 }
 
+func newServerlessClusterResumeCmd() *cobra.Command {
+	var serverlessClusterId string
+
+	serverlessClusterResumeCmd := &cobra.Command{
+		Use:     "resume",
+		Short:   "This command resumes Hazelcast Instance according to its id",
+		Example: "hzcloud serverless-cluster resume --cluster-id=100",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := internal.NewClient()
+			clusterResponse := internal.Validate(client.ServerlessCluster.Resume(context.Background(), &models.ClusterResumeInput{
+				ClusterId: serverlessClusterId,
+			})).(*models.ClusterId)
+			color.Blue("Cluster %d resumed.", clusterResponse.ClusterId)
+		},
+	}
+
+	serverlessClusterResumeCmd.Flags().StringVar(&serverlessClusterId, "cluster-id", "", "id of the cluster")
+	_ = serverlessClusterResumeCmd.MarkFlagRequired("cluster-id")
+
+	return serverlessClusterResumeCmd
+}
+
 func init() {
 	serverlessClusterCmd := newServerlessClusterCmd()
 	rootCmd.AddCommand(serverlessClusterCmd)
@@ -152,4 +174,5 @@ func init() {
 	serverlessClusterCmd.AddCommand(newServerlessClusterGetCmd())
 	serverlessClusterCmd.AddCommand(newServerlessClusterDeleteCmd())
 	serverlessClusterCmd.AddCommand(newServerlessClusterStopCmd())
+	serverlessClusterCmd.AddCommand(newServerlessClusterResumeCmd())
 }

--- a/cmd/serverless_cluster.go
+++ b/cmd/serverless_cluster.go
@@ -28,6 +28,7 @@ func getServerlessClusterCreateCmd() *cobra.Command {
 		},
 	}
 
+	createClusterInputParams.ClusterType = models.Serverless
 	serverlessClusterCreateCmd.Flags().StringVar(&createClusterInputParams.Name, "name", "", "name of the cluster (required)")
 	_ = serverlessClusterCreateCmd.MarkFlagRequired("name")
 	serverlessClusterCreateCmd.Flags().StringVar(&createClusterInputParams.Region, "region", "", "name of the region (required)")

--- a/cmd/serverless_cluster.go
+++ b/cmd/serverless_cluster.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"github.com/fatih/color"
+	"github.com/hazelcast/hazelcast-cloud-cli/internal"
+	"github.com/hazelcast/hazelcast-cloud-sdk-go/models"
+	"github.com/spf13/cobra"
+)
+
+var serverlessClusterCmd = &cobra.Command{
+	Use:     "serverless-cluster",
+	Aliases: []string{"slc"},
+	Short:   "This command allows you to make actions on your serverless clusters like: create, delete, stop or resume.",
+}
+
+func getServerlessClusterCreateCmd() *cobra.Command {
+	var createClusterInputParams models.CreateServerlessClusterInput
+
+	serverlessClusterCreateCmd := cobra.Command{
+		Use:   "create",
+		Short: "hzcloud serverless-cluster create --name=mycluster --region=us-west-2",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := internal.NewClient()
+			cluster := internal.Validate(client.ServerlessCluster.Create(context.Background(), &createClusterInputParams)).(*models.Cluster)
+			color.Green("Cluster %s is creating. You can check the status using hzcloud serverless-cluster list.", cluster.Id)
+			return nil
+		},
+	}
+
+	serverlessClusterCreateCmd.Flags().StringVar(&createClusterInputParams.Name, "name", "", "name of the cluster (required)")
+	_ = serverlessClusterCreateCmd.MarkFlagRequired("name")
+	serverlessClusterCreateCmd.Flags().StringVar(&createClusterInputParams.Region, "region", "", "name of the region (required)")
+	_ = serverlessClusterCreateCmd.MarkFlagRequired("region")
+
+	return &serverlessClusterCreateCmd
+}
+
+func init() {
+	rootCmd.AddCommand(serverlessClusterCmd)
+	serverlessClusterCmd.AddCommand(getServerlessClusterCreateCmd())
+}

--- a/cmd/serverless_cluster.go
+++ b/cmd/serverless_cluster.go
@@ -79,7 +79,7 @@ func newServerlessClusterGetCmd() *cobra.Command {
 
 	serverlessClusterGetCmd := cobra.Command{
 		Use:     "get",
-		Short:   "This command get detailed configuration of serverless Hazelcast cluster instance.",
+		Short:   "This command get detailed configuration of a serverless Hazelcast cluster.",
 		Example: "hzcloud serverless-cluster get --cluster-id=100",
 		Run: func(cmd *cobra.Command, args []string) {
 			client := internal.NewClient()
@@ -99,6 +99,28 @@ func newServerlessClusterGetCmd() *cobra.Command {
 	return &serverlessClusterGetCmd
 }
 
+func newServerlessClusterDeleteCmd() *cobra.Command {
+	var serverlessClusterId string
+
+	serverlessClusterDeleteCmd := &cobra.Command{
+		Use:     "delete",
+		Short:   "This command deletes a serverless Hazelcast cluster.",
+		Example: "hzcloud serverless-cluster delete --cluster-id=100",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := internal.NewClient()
+			clusterResponse := internal.Validate(client.ServerlessCluster.Delete(context.Background(), &models.ClusterDeleteInput{
+				ClusterId: serverlessClusterId,
+			})).(*models.ClusterId)
+			color.Blue("Cluster %d deleted.", clusterResponse.ClusterId)
+		},
+	}
+
+	serverlessClusterDeleteCmd.Flags().StringVar(&serverlessClusterId, "cluster-id", "", "id of the cluster")
+	_ = serverlessClusterDeleteCmd.MarkFlagRequired("cluster-id")
+
+	return serverlessClusterDeleteCmd
+}
+
 func init() {
 	serverlessClusterCmd := newServerlessClusterCmd()
 	rootCmd.AddCommand(serverlessClusterCmd)
@@ -106,4 +128,5 @@ func init() {
 	serverlessClusterCmd.AddCommand(newServerlessClusterCreateCmd())
 	serverlessClusterCmd.AddCommand(newServerlessClusterListCmd())
 	serverlessClusterCmd.AddCommand(newServerlessClusterGetCmd())
+	serverlessClusterCmd.AddCommand(newServerlessClusterDeleteCmd())
 }

--- a/cmd/serverless_cluster.go
+++ b/cmd/serverless_cluster.go
@@ -14,18 +14,24 @@ func newServerlessClusterCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "serverless-cluster",
 		Aliases: []string{"slc"},
-		Short:   "This command allows you to make actions on your serverless clusters like: create, delete, stop or resume.",
+		Short:   "This command allows you to make actions on your serverless clusters like: create, delete, get, list, stop or resume.",
 	}
 }
 
 func newServerlessClusterCreateCmd() *cobra.Command {
 	var createClusterInputParams models.CreateServerlessClusterInput
+	var devModeEnabled bool
 
 	serverlessClusterCreateCmd := cobra.Command{
 		Use:     "create",
-		Short:   "This command allows you to create a serverless cluster.",
+		Short:   "This command allows you to create a serverless Hazelcast cluster.",
 		Example: "hzcloud serverless-cluster create --name=mycluster --region=us-west-2",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if devModeEnabled {
+				createClusterInputParams.ClusterType = models.Devmode
+			} else {
+				createClusterInputParams.ClusterType = models.Serverless
+			}
 			client := internal.NewClient()
 			cluster := internal.Validate(client.ServerlessCluster.Create(context.Background(), &createClusterInputParams)).(*models.Cluster)
 			color.Green("Cluster %s is creating. You can check the status using hzcloud serverless-cluster list.", cluster.Id)
@@ -39,20 +45,15 @@ func newServerlessClusterCreateCmd() *cobra.Command {
 	serverlessClusterCreateCmd.Flags().StringVar(&createClusterInputParams.Region, "region", "", "name of the region (required)")
 	_ = serverlessClusterCreateCmd.MarkFlagRequired("region")
 
-	var devModeEnabled bool
 	serverlessClusterCreateCmd.Flags().BoolVar(&devModeEnabled, "dev-mode-enabled", false, "development mode")
-	if devModeEnabled {
-		createClusterInputParams.ClusterType = models.Devmode
-	} else {
-		createClusterInputParams.ClusterType = models.Serverless
-	}
+
 	return &serverlessClusterCreateCmd
 }
 
 func newServerlessClusterListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
-		Short:   "This command allows you to create a serverless cluster.",
+		Short:   "This command allows you to create a serverless Hazelcast cluster.",
 		Example: "hzcloud serverless-cluster list",
 		Run: func(cmd *cobra.Command, args []string) {
 			client := internal.NewClient()
@@ -126,7 +127,7 @@ func newServerlessClusterStopCmd() *cobra.Command {
 
 	serverlessClusterStopCmd := &cobra.Command{
 		Use:     "stop",
-		Short:   "This command allows you to stop a Hazelcast cluster.",
+		Short:   "This command allows you to stop a serverless Hazelcast cluster.",
 		Example: "hzcloud serverless-cluster stop --cluster-id=100",
 		Run: func(cmd *cobra.Command, args []string) {
 			client := internal.NewClient()
@@ -148,7 +149,7 @@ func newServerlessClusterResumeCmd() *cobra.Command {
 
 	serverlessClusterResumeCmd := &cobra.Command{
 		Use:     "resume",
-		Short:   "This command resumes Hazelcast Instance according to its id",
+		Short:   "This command allows you to resume a serverless Hazelcast cluster.",
 		Example: "hzcloud serverless-cluster resume --cluster-id=100",
 		Run: func(cmd *cobra.Command, args []string) {
 			client := internal.NewClient()

--- a/cmd/serverless_cluster.go
+++ b/cmd/serverless_cluster.go
@@ -8,13 +8,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var serverlessClusterCmd = &cobra.Command{
-	Use:     "serverless-cluster",
-	Aliases: []string{"slc"},
-	Short:   "This command allows you to make actions on your serverless clusters like: create, delete, stop or resume.",
+func newServerlessClusterCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "serverless-cluster",
+		Aliases: []string{"slc"},
+		Short:   "This command allows you to make actions on your serverless clusters like: create, delete, stop or resume.",
+	}
 }
 
-func getServerlessClusterCreateCmd() *cobra.Command {
+func newServerlessClusterCreateCmd() *cobra.Command {
 	var createClusterInputParams models.CreateServerlessClusterInput
 
 	serverlessClusterCreateCmd := cobra.Command{
@@ -28,16 +30,24 @@ func getServerlessClusterCreateCmd() *cobra.Command {
 		},
 	}
 
-	createClusterInputParams.ClusterType = models.Serverless
 	serverlessClusterCreateCmd.Flags().StringVar(&createClusterInputParams.Name, "name", "", "name of the cluster (required)")
 	_ = serverlessClusterCreateCmd.MarkFlagRequired("name")
+
 	serverlessClusterCreateCmd.Flags().StringVar(&createClusterInputParams.Region, "region", "", "name of the region (required)")
 	_ = serverlessClusterCreateCmd.MarkFlagRequired("region")
 
+	var devModeEnabled bool
+	serverlessClusterCreateCmd.Flags().BoolVar(&devModeEnabled, "dev-mode-enabled", false, "development mode")
+	if devModeEnabled {
+		createClusterInputParams.ClusterType = models.Devmode
+	} else {
+		createClusterInputParams.ClusterType = models.Serverless
+	}
 	return &serverlessClusterCreateCmd
 }
 
 func init() {
+	serverlessClusterCmd := newServerlessClusterCmd()
 	rootCmd.AddCommand(serverlessClusterCmd)
-	serverlessClusterCmd.AddCommand(getServerlessClusterCreateCmd())
+	serverlessClusterCmd.AddCommand(newServerlessClusterCreateCmd())
 }

--- a/cmd/serverless_cluster.go
+++ b/cmd/serverless_cluster.go
@@ -104,7 +104,7 @@ func newServerlessClusterDeleteCmd() *cobra.Command {
 
 	serverlessClusterDeleteCmd := &cobra.Command{
 		Use:     "delete",
-		Short:   "This command deletes a serverless Hazelcast cluster.",
+		Short:   "This command allows you to delete a serverless Hazelcast cluster.",
 		Example: "hzcloud serverless-cluster delete --cluster-id=100",
 		Run: func(cmd *cobra.Command, args []string) {
 			client := internal.NewClient()
@@ -121,6 +121,28 @@ func newServerlessClusterDeleteCmd() *cobra.Command {
 	return serverlessClusterDeleteCmd
 }
 
+func newServerlessClusterStopCmd() *cobra.Command {
+	var serverlessClusterId string
+
+	serverlessClusterStopCmd := &cobra.Command{
+		Use:     "stop",
+		Short:   "This command allows you to stop a Hazelcast cluster.",
+		Example: "hzcloud serverless-cluster stop --cluster-id=100",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := internal.NewClient()
+			clusterResponse := internal.Validate(client.ServerlessCluster.Stop(context.Background(), &models.ClusterStopInput{
+				ClusterId: serverlessClusterId,
+			})).(*models.ClusterId)
+			color.Blue("Cluster %d stopped.", clusterResponse.ClusterId)
+		},
+	}
+
+	serverlessClusterStopCmd.Flags().StringVar(&serverlessClusterId, "cluster-id", "", "id of the cluster")
+	_ = serverlessClusterStopCmd.MarkFlagRequired("cluster-id")
+
+	return serverlessClusterStopCmd
+}
+
 func init() {
 	serverlessClusterCmd := newServerlessClusterCmd()
 	rootCmd.AddCommand(serverlessClusterCmd)
@@ -129,4 +151,5 @@ func init() {
 	serverlessClusterCmd.AddCommand(newServerlessClusterListCmd())
 	serverlessClusterCmd.AddCommand(newServerlessClusterGetCmd())
 	serverlessClusterCmd.AddCommand(newServerlessClusterDeleteCmd())
+	serverlessClusterCmd.AddCommand(newServerlessClusterStopCmd())
 }

--- a/cmd/serverless_cluster.go
+++ b/cmd/serverless_cluster.go
@@ -74,10 +74,36 @@ func newServerlessClusterListCmd() *cobra.Command {
 	}
 }
 
+func newServerlessClusterGetCmd() *cobra.Command {
+	var serverlessClusterId string
+
+	serverlessClusterGetCmd := cobra.Command{
+		Use:     "get",
+		Short:   "This command get detailed configuration of serverless Hazelcast cluster instance.",
+		Example: "hzcloud serverless-cluster get --cluster-id=100",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := internal.NewClient()
+			cluster := internal.Validate(client.ServerlessCluster.Get(context.Background(), &models.GetServerlessClusterInput{
+				ClusterId: serverlessClusterId,
+			})).(*models.Cluster)
+			util.Print(util.PrintRequest{
+				Data:       *cluster,
+				PrintStyle: util.PrintStyle(outputStyle),
+			})
+		},
+	}
+
+	serverlessClusterGetCmd.Flags().StringVar(&serverlessClusterId, "cluster-id", "", "id of the cluster")
+	_ = serverlessClusterGetCmd.MarkFlagRequired("cluster-id")
+
+	return &serverlessClusterGetCmd
+}
+
 func init() {
 	serverlessClusterCmd := newServerlessClusterCmd()
 	rootCmd.AddCommand(serverlessClusterCmd)
 
 	serverlessClusterCmd.AddCommand(newServerlessClusterCreateCmd())
 	serverlessClusterCmd.AddCommand(newServerlessClusterListCmd())
+	serverlessClusterCmd.AddCommand(newServerlessClusterGetCmd())
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.3.0
-	github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2
+	github.com/hazelcast/hazelcast-cloud-sdk-go v1.3.0
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2 h1:qeWmMA/oHjwe0cWhFLc+Zu9wlQ2s+GjZLe5n0mOeL/Q=
-github.com/hazelcast/hazelcast-cloud-sdk-go v1.2.2/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.3.0 h1:YKuhdajxufEwY9EJpgBQZSjvPnxyCuBqUdeybPMTdPs=
+github.com/hazelcast/hazelcast-cloud-sdk-go v1.3.0/go.mod h1:3Iane/AnU7k1x2+t4C9BrE6CTGU/T/3i79DVFLbJLkg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/list"
 )
 
-func AugmentStarterClusterType(starterClusterCreateClusterType string) (models.StarterClusterType, error) {
+func AugmentStarterClusterType(starterClusterCreateClusterType string) (models.ClusterType, error) {
 	switch strings.ToUpper(starterClusterCreateClusterType) {
 	case "FREE":
 		return models.Free, nil

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -72,6 +72,11 @@ func printCluster(cluster models.Cluster, printStyle PrintStyle) {
 	wr.AppendItem(fmt.Sprintf("Free: %t", cluster.ProductType.IsFree))
 	wr.UnIndent()
 
+	wr.AppendItem("Cluster Type")
+	wr.Indent()
+	wr.AppendItem(fmt.Sprintf("Name: %s", cluster.ClusterType.Name))
+	wr.UnIndent()
+
 	wr.AppendItem(fmt.Sprintf("State: %s", cluster.State))
 	wr.AppendItem(fmt.Sprintf("Created at: %s", cluster.CreatedAt))
 	wr.AppendItem(fmt.Sprintf("Started at: %s", cluster.StartedAt))


### PR DESCRIPTION
⚠️ Depends on https://github.com/hazelcast/hazelcast-cloud-sdk-go/pull/15 .

```
This command allows you to make actions on your serverless clusters like: create, delete, get, list, stop or resume.

Usage:
  hzcloud serverless-cluster [command]

Aliases:
  serverless-cluster, slc

Available Commands:
  create      This command allows you to create a serverless Hazelcast cluster.
  delete      This command allows you to delete a serverless Hazelcast cluster.
  get         This command get detailed configuration of a serverless Hazelcast cluster.
  list        This command allows you to create a serverless Hazelcast cluster.
  resume      This command allows you to resume a serverless Hazelcast cluster.
  stop        This command allows you to stop a serverless Hazelcast cluster.
```

---

New features (dev mode enabled):
- Add creation serverless clusters support
```
> hzcloud serverless-cluster create --name=mydevcluster --region=us-west-2 --dev-mode-enabled=true
Cluster 46765 is creating. You can check the status using hzcloud serverless-cluster list.
```
- Add creation listing serverless clusters support
```
> hzcloud serverless-cluster list
┌────────┬──────────────┬─────────┬─────────┬─────────┬──────────────┬────────────────┬───────────┐
│ Id     │ Name         │ Type    │ State   │ Version │ Memory (GiB) │ Cloud Provider │ Region    │
├────────┼──────────────┼─────────┼─────────┼─────────┼──────────────┼────────────────┼───────────┤
│ 46765  │ mydevcluster │ DEVMODE │ RUNNING │ 5.1.1   │            1 │ aws            │ us-west-2 │
├────────┼──────────────┼─────────┼─────────┼─────────┼──────────────┼────────────────┼───────────┤
│ Total: │ 1            │         │         │         │              │                │           │
└────────┴──────────────┴─────────┴─────────┴─────────┴──────────────┴────────────────┴───────────┘
```
- Add retrieval serverless clusters support
```
> hzcloud serverless-cluster get --cluster-id=46765
┏━ Id: 46765
┣━ Display Name: mydevcluster
┣━ Cluster Name: ba-46765
┣━ Customer Id: 27014
┣━ Password: 57a0cd843deb4bd7af2187f10bc5bdc5
┣━ Port: 30000
┣━ Hazelcast Version: 5.1.1
┣━ Auto Scaling: Disabled
┣━ Hot Backup: Disabled
┣━ Hot Restart: Disabled
┣━ IP Whitelist: Disabled
┣━ TLS: Enabled
┣━ Product Type
┃  ┣━ Name: STARTER
┃  ┗━ Free: false
┣━ Cluster Type
┃  ┗━ Name: DEVMODE
┣━ State: RUNNING
...
```
- Add stopping serverless clusters support
```
> hzcloud serverless-cluster stop --cluster-id=46765
Cluster 46765 stopped.
```
- Add resuming serverless clusters support
```
> hzcloud serverless-cluster resume --cluster-id=46765
Cluster 46765 resumed.
```
- Add deleting serverless clusters support
```
> hzcloud serverless-cluster delete --cluster-id=46765
Cluster 46765 deleted.
```

---

New features (dev mode disabled):
- Add creation serverless clusters support
```
> hzcloud serverless-cluster create --name=mydevcluster --region=us-west-2
Cluster 46766 is creating. You can check the status using hzcloud serverless-cluster list.
```
- Add creation listing serverless clusters support
```
> hzcloud serverless-cluster list
┌────────┬───────────┬────────────┬─────────┬─────────┬──────────────┬────────────────┬───────────┐
│ Id     │ Name      │ Type       │ State   │ Version │ Memory (GiB) │ Cloud Provider │ Region    │
├────────┼───────────┼────────────┼─────────┼─────────┼──────────────┼────────────────┼───────────┤
│ 46766  │ mycluster │ SERVERLESS │ PENDING │ 5.1.1   │           10 │ aws            │ us-west-2 │
├────────┼───────────┼────────────┼─────────┼─────────┼──────────────┼────────────────┼───────────┤
│ Total: │ 1         │            │         │         │              │                │           │
└────────┴───────────┴────────────┴─────────┴─────────┴──────────────┴────────────────┴───────────┘
```
- Add retrieval serverless clusters support
```
> hzcloud serverless-cluster get --cluster-id=46766
┏━ Id: 46766
┣━ Display Name: mycluster
┣━ Cluster Name: ba-46766
┣━ Customer Id: 27014
┣━ Password: aef0f5bdabcf4e62800e5decf913dd29
┣━ Port: 30000
┣━ Hazelcast Version: 5.1.1
┣━ Auto Scaling: Enabled
┣━ Hot Backup: Enabled
┣━ Hot Restart: Enabled
┣━ IP Whitelist: Disabled
┣━ TLS: Enabled
┣━ Product Type
┃  ┣━ Name: STARTER
┃  ┗━ Free: false
┣━ Cluster Type
┃  ┗━ Name: SERVERLESS
┣━ State: PENDING
...
```
- Add stopping serverless clusters support
```
> hzcloud serverless-cluster stop --cluster-id=46766
Cluster 46766 stopped.
```
- Add resuming serverless clusters support
```
> hzcloud serverless-cluster resume --cluster-id=46766
Cluster 46766 resumed.
```
- Add deleting serverless clusters support
```
> hzcloud serverless-cluster delete --cluster-id=46766
Cluster 46766 deleted.
```